### PR TITLE
Add major version patch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,19 @@ to
 This will allow those patch files to be safely ignored when
 `NODE_ENV=production`.
 
+### Major version patches
+
+You can target an entire major version by renaming a patch file to include only
+the major number. For example, changing
+
+    package-name+1.2.3.patch
+
+to
+
+    package-name+1.patch
+
+will apply the patch to any installed `1.x` version of the package.
+
 ### Creating multiple patches for the same package
 
 _💡 This is an advanced feature and is not recommended unless you really, really

--- a/src/PackageDetails.test.ts
+++ b/src/PackageDetails.test.ts
@@ -344,4 +344,14 @@ Object {
 }
 `)
   })
+
+  it("works for major versions", () => {
+    expect(parseNameAndVersion("left-pad+1")).toMatchInlineSnapshot(`
+Object {
+  "matchMajor": true,
+  "packageName": "left-pad",
+  "version": "1",
+}
+`)
+  })
 })


### PR DESCRIPTION
## Summary
- parse patch filenames that specify only major version
- apply patches based on major version when `+<major>.patch` is used
- document major version patches in README
- test major version parsing

## Testing
- `yarn build` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/...)*
- `./run-tests.sh` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/...)*

------
https://chatgpt.com/codex/tasks/task_e_687aa7e489e08326a4bcce0b094ed4bf